### PR TITLE
Prepare for release v0.1.0-beta.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20200922210707-59bab27e5d41
 	kmodules.xyz/offshoot-api v0.0.0-20201027120238-b5c30f198112
 	kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
-	kubedb.dev/apimachinery v0.14.0-beta.5.0.20201027120621-cd358dda127d
+	kubedb.dev/apimachinery v0.14.0-beta.6
 	stash.appscode.dev/apimachinery v0.11.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1561,8 +1561,8 @@ kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e h1:NASVP0dOE5Zdlq+3Op7Fh2
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e/go.mod h1:AZ58K5hrxkkNPf8tM+UWeZjtNG3/mn192nKcUyC93F8=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de h1:uWgv78OoOWx9eQdu6SEkPopvbpnL8WxZEMNd3/Oye2w=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de/go.mod h1:5A8s2nvrNAZGrt0OlsiiuZIik3xWyKW6+ZSwgljIm78=
-kubedb.dev/apimachinery v0.14.0-beta.5.0.20201027120621-cd358dda127d h1:Ica6GbsHseqfsnInCxwFKTPaLqga1kklZCyHuV2WFv0=
-kubedb.dev/apimachinery v0.14.0-beta.5.0.20201027120621-cd358dda127d/go.mod h1:em0oWivOXYZUMj4fZ4wLIIfr86eyzogAcZ6GDcnplvY=
+kubedb.dev/apimachinery v0.14.0-beta.6 h1:HuM/2TRM/IFlssB9j/Ri8VS9EEiiuOWVAHdWpZq2R9E=
+kubedb.dev/apimachinery v0.14.0-beta.6/go.mod h1:em0oWivOXYZUMj4fZ4wLIIfr86eyzogAcZ6GDcnplvY=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1142,7 +1142,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.5.0.20201027120621-cd358dda127d
+# kubedb.dev/apimachinery v0.14.0-beta.6
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/17
Signed-off-by: 1gtm <1gtm@appscode.com>