### PR TITLE
Prepare for release v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20201105133858-cbb2af88d50a
 	kmodules.xyz/offshoot-api v0.0.0-20201105074700-8675f5f686f2
 	kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
-	kubedb.dev/apimachinery v0.16.0
+	kubedb.dev/apimachinery v0.16.1
 	stash.appscode.dev/apimachinery v0.11.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1486,8 +1486,8 @@ kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8 h1:UJb5lHQVFKbmlgmRLq5IWJ
 kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8/go.mod h1:2eN8X5Wq7/AAgE5AWMAX8T0lE51HZiYEldG2RQuouX4=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6 h1:9+EIwxUrXrM8QD9rC1Fg+6CQK0vPniFO3ClaKih010M=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
-kubedb.dev/apimachinery v0.16.0 h1:nUNepbAHOZ1llU0PtXemSGHNUIPFcbCdoc8xh3fDudA=
-kubedb.dev/apimachinery v0.16.0/go.mod h1:jfH9wMWLd+rgDagKSFegJ1OJE8FU3V3rc+0dBCdi1sk=
+kubedb.dev/apimachinery v0.16.1 h1:KIv0QZhVdEdfLL9M2rAeuMR6WYGGWFttGuwaTXa93kQ=
+kubedb.dev/apimachinery v0.16.1/go.mod h1:jfH9wMWLd+rgDagKSFegJ1OJE8FU3V3rc+0dBCdi1sk=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -130,8 +130,10 @@ const (
 	MongoDBInitInstallContainerName   = "copy-config"
 	MongoDBInitBootstrapContainerName = "bootstrap"
 
-	MongoDBConfigDirectoryName        = "configdir"
-	MongoDBConfigDirectoryPath        = "/data/configdb"
+	MongoDBConfigDirectoryName = "config"
+	MongoDBConfigDirectoryPath = "/data/configdb"
+
+	MongoDBInitialConfigDirectoryName = "configdir"
 	MongoDBInitialConfigDirectoryPath = "/configdb-readonly"
 
 	MongoDBInitScriptDirectoryName = "init-scripts"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1142,7 +1142,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.16.0
+# kubedb.dev/apimachinery v0.16.1
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.01.15
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/30
Signed-off-by: 1gtm <1gtm@appscode.com>